### PR TITLE
update name of architecture

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -8,4 +8,4 @@ category=Sensors
 url=http://www.tinymlx.org
 includes=TinyMLShield.h
 ldflags=-lm
-architectures=mbed
+architectures=mbed_nano


### PR DESCRIPTION
the new version of the core for Arduino Nano 33 BLE Sense is now named mbed_nano