### PR TITLE
Cant compile a break outside of a loop:  if (IMU.gyroscopeAvailable()…

### DIFF
--- a/examples/magic_wand/imu_provider.h
+++ b/examples/magic_wand/imu_provider.h
@@ -99,7 +99,6 @@ namespace {
       // Read each sample, removing it from the device's FIFO buffer
       if (!IMU.readGyroscope(data[0], data[1], data[2])) {
         Serial.println("Failed to read gyroscope data");
-        break;
       }
       new_samples += 1;
     }


### PR DESCRIPTION
Cant compile a break outside of a loop: 
 _if (IMU.gyroscopeAvailable() {_ 
used to be a while loop, but if we switch to an if statement
as per: 
commit 40b247d17fc2d9696b85aaa841c78befe4b7361f
https://github.com/tinyMLx/arduino-library/blame/main/examples/magic_wand/imu_provider.h

then we must remove the break.
All this commit does is remove the break. 
